### PR TITLE
broadening the scope of the CoC (#6)

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -52,8 +52,7 @@ decisions when appropriate.
 
 == Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces such as social media, forums, and online and offline events.
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event, or any space where the project is listed as part of your profile. Representation of a project may be further defined and clarified by project maintainers.
 
 
 == Enforcement


### PR DESCRIPTION
changed our minimized Scope section to the exact one from [Contributor Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) as that one is broader and covers more bases.